### PR TITLE
removed test subsets

### DIFF
--- a/allegro_klej_dyk_questions.py
+++ b/allegro_klej_dyk_questions.py
@@ -1,3 +1,9 @@
+"""
+Instructions creator based on allegro klej-dyk dataset
+
+Removed test subset in Pull Request #15
+"""
+
 import os
 import pandas as pd
 import json
@@ -21,12 +27,13 @@ if not os.path.exists(data_dir):
 if not os.path.exists(output_dir):
     os.makedirs(output_dir)
 
-file_path_1 = download_file(
-    "https://huggingface.co/datasets/allegro/klej-dyk/resolve/main/test.csv?download=true",
-    data_dir,
-    "allegro-klej-dyk-test.csv"
-)
-json_path_1 = os.path.join(output_dir, "allegro-klej-dyk_test.json")
+# Removed in Pull Request #15
+# file_path_1 = download_file(
+#     "https://huggingface.co/datasets/allegro/klej-dyk/resolve/main/test.csv?download=true",
+#     data_dir,
+#     "allegro-klej-dyk-test.csv"
+# )
+# json_path_1 = os.path.join(output_dir, "allegro-klej-dyk_test.json")
 
 file_path_2 = download_file(
     "https://huggingface.co/datasets/allegro/klej-dyk/resolve/main/train.csv?download=true",
@@ -55,5 +62,5 @@ def create_instruction(instruction, file_path, json_path):
         json.dump(instructions, f, indent=4, ensure_ascii=False)
 
 
-create_instruction("Odpowiedz na pytanie.", file_path_1, json_path_1)
+# create_instruction("Odpowiedz na pytanie.", file_path_1, json_path_1) # Removed in Pull Request #15
 create_instruction("Odpowiedz na pytanie.", file_path_2, json_path_2)

--- a/emplocity_owca_questions.py
+++ b/emplocity_owca_questions.py
@@ -32,7 +32,7 @@ def download_dataset(dataset: str = "emplocity/owca", split:str = "train") -> pd
     Download and load a dataset to the frame.
 
     :param dataset: The name or path of the dataset.
-    :param split: The dataset split to download (e.g., "train", "validation", "test").
+    :param split: The dataset split to download (e.g., "train", "validation").
     :return: A Pandas DataFrame containing the downloaded dataset.
     """
     dataset = load_dataset(dataset, split=split)

--- a/exams_questions.py
+++ b/exams_questions.py
@@ -33,7 +33,7 @@ def download_dataset(dataset: str = "exams", subset:str = "crosslingual_pl", spl
 
     :param dataset: The name or path of the dataset.
     :param subset: The subset or category of the dataset to download.
-    :param split: The dataset split to download (e.g., "train", "validation", "test").
+    :param split: The dataset split to download (e.g., "train", "validation").
     :return: A Pandas DataFrame containing the downloaded dataset.
     """
     dataset = load_dataset(dataset, subset, split=split)

--- a/ipipan_polqa_questions.py
+++ b/ipipan_polqa_questions.py
@@ -1,4 +1,9 @@
-"""Instructions creator based on polqa dataset"""
+"""
+Instructions creator based on polqa dataset
+
+Removed test subset in Pull Request #15
+"""
+
 import json
 import os
 import random
@@ -85,7 +90,7 @@ def create_instruction(instruction: str, file_path: str, json_path: str) -> None
 
 
 if __name__ == '__main__':
-    files = ['test', 'train', 'valid']
+    files = ['train', 'valid']
     for file in files:
         file_path, json_path = downloader(file)
         create_instruction("Odpowiedz na pytanie.", file_path, json_path)

--- a/legal-questions.py
+++ b/legal-questions.py
@@ -1,3 +1,8 @@
+"""
+Instructions creator based on legal-questions
+
+DISCLAIMER: the dataset is based on the test subset, so it was removed from instructions merging in the PR#15
+"""
 import os
 import pandas as pd
 import json

--- a/merge_files.py
+++ b/merge_files.py
@@ -14,7 +14,6 @@ generate = False
 
 scipts_to_run = []
 scipts_to_run.append({"script_name" : "allegro_klej_dyk_questions.py", "author" : "Ic & MariaF", "category": "KNOWLEDGE_QA"})
-scipts_to_run.append({"script_name" : "legal-questions.py", "author" : "Ic & MariaF", "category": "KNOWLEDGE_LEGAL_QA"})
 scipts_to_run.append({"script_name" : "polish-summaries-corpus.py", "author" : "Ic & MariaF", "category": "NLP_SUMMARIZATION"})
 scipts_to_run.append({"script_name" : "polqa_questions.py", "author" : "Ic & MariaF", "category": "KNOWLEDGE_QA"})
 scipts_to_run.append({"script_name" : "poquad_text_extraction.py", "author" : "Ic & MariaF", "category": "KNOWLEDGE_QA"})

--- a/polish-news-summarization.py
+++ b/polish-news-summarization.py
@@ -33,7 +33,7 @@ def download_dataset(dataset: str = "WiktorS/polish-news", split:str = "train") 
 
     :param dataset: The name or path of the dataset.
     :param subset: The subset or category of the dataset to download.
-    :param split: The dataset split to download (e.g., "train", "validation", "test").
+    :param split: The dataset split to download (e.g., "train", "validation").
     :return: A Pandas DataFrame containing the downloaded dataset.
     """
     dataset = load_dataset(dataset, split=split)


### PR DESCRIPTION
Certain instructions with test subsets are duplicating benchmarks, so the following modifications were made:

- `ipipan_polqa_questions.py` test subset won't duplicate `PolQA` benchmark.
- `allegro_klej_dyk_questions `test subset won't duplicate `DYK` benchmark.
- `legal_questions.py` was removed from the operation of merging instructions files in `merge_files.py`, because `legal questions` benchmark mirrors it.

Also minor descriptions were added and modified if needed.